### PR TITLE
feat: add linter to enforce copyright header

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,37 @@
+const ERROR = 2;
+
+module.exports = {
+    env: {
+        'browser': true,
+        'es2021': true,
+        'node': true
+    },
+    extends: ['next/core-web-vitals', 'prettier', 'plugin:react/recommended'],
+    overrides: [
+        {
+            env: {
+                'node': true
+            },
+            files: [
+                '.eslintrc.{js,cjs}'
+            ],
+            parserOptions: {
+                'sourceType': 'script'
+            }
+        }
+    ],
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+    },
+    plugins: [
+        '@typescript-eslint',
+        'react',
+        'cdp-project',
+    ],
+    rules: {
+      'cdp-project/require-copyright': ERROR,
+      'react/react-in-jsx-scope': 'off',
+    }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals", "prettier"]
-}

--- a/eslint/rules/index.js
+++ b/eslint/rules/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+  rules: {
+    'require-copyright': require('./require-copyright'),
+  }
+};

--- a/eslint/rules/require-copyright.js
+++ b/eslint/rules/require-copyright.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const COPYRIGHT_DECLARATION = 'Copyright (c) Meta Platforms, Inc. and affiliates.';
+const COPYRIGHT_HEADER = `/**
+ * ${COPYRIGHT_DECLARATION}
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */`;
+
+module.exports = {
+  constants: {
+    COPYRIGHT_HEADER,
+    COPYRIGHT_DECLARATION,
+  },
+  meta: {
+    messages: {
+      requireCopyright: 'All files must have a copyright header',
+      requireCompoundCopyright: `This copyright header must include: ${COPYRIGHT_HEADER}`,
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      Program() {
+        const src = context.getSourceCode();
+        const hasShebang = src.text.startsWith('#!');
+
+        const suspectedCopyright = src.getAllComments().filter(block => 
+          block.type == 'Block' && /Copyright/i.test(block.value)
+        );
+
+        const hasHeader = suspectedCopyright.length > 0;
+
+        let hasCopyrightMentionMeta = false;
+        let copyrightCount = 0;
+        let loc = {line: 0, column: 0};
+
+        if (hasHeader) {
+          const header = suspectedCopyright[0].value;
+          loc = suspectedCopyright[0].loc.start;
+
+          const hasValidHeader = COPYRIGHT_HEADER === `/**${header}*/`;
+          if (hasValidHeader) {
+            return;
+          }
+
+          copyrightCount = header.match(/Copyright/g).length;
+          hasCopyrightMentionMeta = /Copyright.+\bMeta\b/.test(header);
+
+          const hasCorrectCompoundHeader = copyrightCount > 0 && header.indexOf(COPYRIGHT_DECLARATION) !== -1;
+          if (hasCorrectCompoundHeader) {
+            return;
+          }
+        }
+
+        // We can scorch earth here and do the right thing.
+        const canRewrite = copyrightCount === 1 && hasCopyrightMentionMeta;
+
+        if (!canRewrite && copyrightCount > 0) {
+          if (hasCopyrightMentionMeta) {
+            // We give up here and depend on the user to fix this.
+            context.report({
+              loc,
+              messageId: 'requireCompoundCopyright',
+            });
+          } else {
+            context.report({
+              loc,
+              messageId: 'requireCompoundCopyright',
+              fix(fixer) {
+                return fixer.replaceTextRange([0, 3], `/**\n * ${COPYRIGHT_DECLARATION}\n *\n`);
+              }
+            });
+          }
+          return;
+        }
+
+        context.report({
+          loc,
+          messageId: 'requireCopyright',
+          fix(fixer) {
+            if (suspectedCopyright.length > 0) {
+              return fixer.replaceTextRange(suspectedCopyright[0].range, COPYRIGHT_HEADER);
+            }
+            return fixer.insertTextAfterRange(
+              hasShebang ? [0, src.text.indexOf('\n') + 1] : [0, 0], COPYRIGHT_HEADER + '\n\n'
+            );
+          }
+        });
+      },
+    };
+  },
+};

--- a/eslint/rules/require-copyright.test.js
+++ b/eslint/rules/require-copyright.test.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const {RuleTester} = require('eslint');
+const {constants, ...requireCopyright} = require('./require-copyright');
+
+const COPYRIGHT_HEADER = constants.COPYRIGHT_HEADER + '\n\n';
+const {COPYRIGHT_DECLARATION} = constants;
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015 }
+});
+
+ruleTester.run(
+  'require-copyright',
+  requireCopyright,
+  {
+    valid: [
+      {code: `#!/usr/bin/node 
+
+${COPYRIGHT_HEADER}`},
+      {code: COPYRIGHT_HEADER},
+      {code: `/*
+ * ${COPYRIGHT_DECLARATION}
+ *
+ * Copyright 2014 The Chromium Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * ...
+ */`},
+    ],
+    invalid: [
+      {code: '', output: COPYRIGHT_HEADER, errors: 1},
+      {code: `/*
+ * Copyright (c) Foobar
+ */
+
+const action = 'prepend';`,
+        output: `/**
+ * ${COPYRIGHT_DECLARATION}
+ *
+ * Copyright (c) Foobar
+ */
+
+const action = 'prepend';`,
+        errors: 1,
+      },
+      {code: `/*
+ * Copyright (c) Meta - Malformed
+ */
+
+const action = 'replace';`,
+        output: `${COPYRIGHT_HEADER}const action = 'replace';`,
+        errors: 1,
+      },
+      {code: `/**
+ * Copyright (c) Meta - Malformed
+ *
+ * Copyright 2014 The Chromium Authors.All rights reserved.
+ */
+
+const action = 'give up';`,
+        errors: 1,
+      },
+      {
+        code: '/* Dummy Header */',
+        output: `${COPYRIGHT_HEADER}/* Dummy Header */`,
+        errors: 1,
+      },
+      {
+        code: `/*
+ * Copyright 2014 The Chromium Authors. All rights reserved.
+ */`,
+        output: `/**
+ * ${COPYRIGHT_DECLARATION}
+ *
+ * Copyright 2014 The Chromium Authors. All rights reserved.
+ */`,
+        errors: 1,
+      },
+    ],
+  }
+);
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  eslint: {
+    dirs: [
+      'app',
+      'third-party',
+      'ui',
+      'data',
+      'eslint'
+    ],
+  }
+};
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-timeago": "^7.2.0",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
-    "sass": "^1.69.3"
+    "sass": "^1.69.3",
+    "eslint-plugin-cdp-project": "file:./eslint/rules"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
@@ -30,10 +31,13 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-timeago": "^4.1.4",
+    "@typescript-eslint/eslint-plugin": "^6.8.0",
+    "@typescript-eslint/parser": "^6.8.0",
     "autoprefixer": "^10",
     "eslint": "^8",
     "eslint-config-next": "13.5.4",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-react": "^7.33.2",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
     "postcss": "^8",


### PR DESCRIPTION
Makes sure we have a valid Meta copyright, executed as part of:

	yarn lint

## Finds and fixes
<img width="752" alt="CleanShot 2023-10-23 at 19 29 18@2x" src="https://github.com/facebook/react-native-cdp-status/assets/49578/f64bd5b3-9aa6-4462-ab75-d3c0d90229ef">

## Fix changes
<img width="613" alt="CleanShot 2023-10-23 at 19 27 26@2x" src="https://github.com/facebook/react-native-cdp-status/assets/49578/3e624eca-9c9b-41df-8d45-f877ac8bee3c">
