### PR TITLE
Specify '(main)' in version labels

### DIFF
--- a/data/ProtocolVersionsModel.tsx
+++ b/data/ProtocolVersionsModel.tsx
@@ -193,7 +193,7 @@ NOTE: The "Hermes" protocol version is a subset of \`latest\` filtered automatic
 * Protocol messages currently implemented in Hermes.
 * Protocol types referenced transitively by those messages - including types that might not be implemented/referenced in the Hermes code.
   `,
-              versionName: 'hermes',
+              versionName: 'hermes (main)',
               versionSlug: 'hermes',
               dataSource: {
                 github: {
@@ -220,7 +220,7 @@ NOTE: The "Hermes" protocol version is a subset of \`latest\` filtered automatic
               description: `
 NOTE: The "React Native + Hermes" protocol version is a subset of \`latest\` filtered automatically to include only protocol messages implemented in React Native or Hermes (or both).
 `,
-              versionName: 'React Native + Hermes',
+              versionName: 'React Native + Hermes (main)',
               versionSlug: 'react-native-hermes',
               dataSource: {
                 github: {


### PR DESCRIPTION
An inline reminder that this is the live implementation status, and not necessarily for the latest React Native version.

<img width="327" alt="image" src="https://github.com/facebook/react-native-cdp-status/assets/2547783/68cf93a0-5b03-463e-83fb-ebe470299744">
