### PR TITLE
Scrape modern Hermes implementation (CDPAgent) instead of CDPHandler, enable `@cdp` comments

### DIFF
--- a/app/devtools-protocol/[version]/ImplementationLink.tsx
+++ b/app/devtools-protocol/[version]/ImplementationLink.tsx
@@ -28,7 +28,7 @@ export async function ImplementationLink({
             width={20}
             height={20}
             alt=""
-            title="Hermes CDPHandler"
+            title="Hermes CDPAgent"
             className="inline-block mb-1"
           />
         </>

--- a/app/devtools-protocol/[version]/ImplementationLink.tsx
+++ b/app/devtools-protocol/[version]/ImplementationLink.tsx
@@ -35,6 +35,22 @@ export async function ImplementationLink({
       );
       break;
 
+    case 'hermes-legacy':
+      linkContents = (
+        <>
+          Hermes (legacy){' '}
+          <Image
+            src="/images/hermes-logo.svg"
+            width={20}
+            height={20}
+            alt=""
+            title="Hermes CDPHandler"
+            className="inline-block mb-1 grayscale"
+          />
+        </>
+      );
+      break;
+      
     case 'react-native':
       linkContents = (
         <>

--- a/app/devtools-protocol/[version]/[domain]/DomainEventsCard.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainEventsCard.tsx
@@ -28,7 +28,7 @@ export function DomainEventsCard({
     domain.events != null &&
     domain.events?.length !== 0 && (
       <>
-        <h2 className="font-bold text-lg mt-4 mb-2 max-w-4xl mx-auto">
+        <h2 className="font-bold text-lg mt-4 mb-2 max-w-5xl mx-auto">
           Events
         </h2>
         <Card>

--- a/app/devtools-protocol/[version]/[domain]/DomainMemberExternalComments.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMemberExternalComments.tsx
@@ -32,6 +32,17 @@ function CommentImplementationIcon({
           className="inline-block mb-1"
         />
       );
+    case 'hermes-legacy':
+      return (
+        <Image
+          src="/images/hermes-logo.svg"
+          width={20}
+          height={20}
+          alt=""
+          title="Hermes CDPHandler"
+          className="inline-block mb-1 grayscale"
+        />
+      );
     case 'react-native':
       return (
         <Image
@@ -171,6 +182,13 @@ export function DomainMemberExternalComments({
       <DomainMemberExternalCommentsForImplementation
         domain={domain}
         implementationId="hermes"
+        kind={kind}
+        memberKey={memberKey}
+        protocolImplementationData={protocolImplementationData}
+      />
+      <DomainMemberExternalCommentsForImplementation
+        domain={domain}
+        implementationId="hermes-legacy"
         kind={kind}
         memberKey={memberKey}
         protocolImplementationData={protocolImplementationData}

--- a/app/devtools-protocol/[version]/[domain]/DomainMemberExternalComments.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMemberExternalComments.tsx
@@ -168,6 +168,13 @@ export function DomainMemberExternalComments({
         memberKey={memberKey}
         protocolImplementationData={protocolImplementationData}
       />
+      <DomainMemberExternalCommentsForImplementation
+        domain={domain}
+        implementationId="hermes"
+        kind={kind}
+        memberKey={memberKey}
+        protocolImplementationData={protocolImplementationData}
+      />
     </div>
   );
 }

--- a/app/devtools-protocol/[version]/[domain]/DomainMemberExternalComments.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMemberExternalComments.tsx
@@ -28,7 +28,7 @@ function CommentImplementationIcon({
           width={20}
           height={20}
           alt=""
-          title="Hermes CDPHandler"
+          title="Hermes CDPAgent"
           className="inline-block mb-1"
         />
       );

--- a/app/devtools-protocol/[version]/[domain]/DomainMemberExternalLinks.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMemberExternalLinks.tsx
@@ -44,6 +44,13 @@ export function DomainMemberExternalLinks({
       />
       <DomainMemberImplementationLink
         domain={domain}
+        implementationId="hermes-legacy"
+        kind={kind}
+        memberKey={memberKey}
+        protocolImplementationData={protocolImplementationData}
+      />
+      <DomainMemberImplementationLink
+        domain={domain}
         implementationId="react-native"
         kind={kind}
         memberKey={memberKey}

--- a/app/devtools-protocol/[version]/[domain]/DomainMemberHeading.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMemberHeading.tsx
@@ -40,7 +40,7 @@ export function DomainMemberHeading({
         protocolMetadata={protocolMetadata}
       />
       <h3
-        className="font-bold text-lg mt-4 mb-2 max-w-4xl mx-auto font-mono"
+        className="font-bold text-lg mt-4 mb-2 max-w-5xl mx-auto font-mono"
         id={`${kind}-${encodeURIComponent(key)}`}
       >
         <DimText>{domain}.</DimText>

--- a/app/devtools-protocol/[version]/[domain]/DomainMemberImplementationLink.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMemberImplementationLink.tsx
@@ -42,7 +42,7 @@ export function DomainMemberImplementationLink({
           width={small ? 20 : 24}
           height={small ? 20 : 24}
           alt="Hermes"
-          title="Referenced in Hermes CDPHandler"
+          title="Referenced in Hermes CDPAgent"
           className="inline-block"
         />
       );

--- a/app/devtools-protocol/[version]/[domain]/DomainMemberImplementationLink.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMemberImplementationLink.tsx
@@ -18,7 +18,7 @@ export function DomainMemberImplementationLink({
   protocolImplementationData,
   small,
 }: {
-  implementationId: 'hermes' | 'react-native' | 'react-native-hermes';
+  implementationId: 'hermes' | 'hermes-legacy' | 'react-native' | 'react-native-hermes';
   kind: 'method' | 'event' | 'type';
   domain: string;
   memberKey: string;
@@ -44,6 +44,19 @@ export function DomainMemberImplementationLink({
           alt="Hermes"
           title="Referenced in Hermes CDPAgent"
           className="inline-block"
+        />
+      );
+      break;
+    }
+    case 'hermes-legacy': {
+      linkContents = (
+        <Image
+          src="/images/hermes-logo.svg"
+          width={small ? 20 : 24}
+          height={small ? 20 : 24}
+          alt="Hermes (Legacy)"
+          title="Referenced in Hermes CDPHandler"
+          className="inline-block grayscale"
         />
       );
       break;

--- a/app/devtools-protocol/[version]/[domain]/DomainMethodsCard.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainMethodsCard.tsx
@@ -29,7 +29,7 @@ export function DomainMethodsCard({
     domain.commands != null &&
     domain.commands?.length !== 0 && (
       <>
-        <h2 className="font-bold text-lg mt-4 mb-2 max-w-4xl mx-auto">
+        <h2 className="font-bold text-lg mt-4 mb-2 max-w-5xl mx-auto">
           Methods
         </h2>
         <Card>

--- a/app/devtools-protocol/[version]/[domain]/DomainTocSection.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainTocSection.tsx
@@ -60,6 +60,14 @@ export function DomainTocSection({
                 />
                 <DomainMemberImplementationLink
                   domain={domain}
+                  implementationId="hermes-legacy"
+                  kind={kind}
+                  memberKey={key}
+                  protocolImplementationData={protocolImplementationData}
+                  small
+                />
+                <DomainMemberImplementationLink
+                  domain={domain}
                   implementationId="react-native"
                   kind={kind}
                   memberKey={key}

--- a/app/devtools-protocol/[version]/[domain]/DomainTypesCard.tsx
+++ b/app/devtools-protocol/[version]/[domain]/DomainTypesCard.tsx
@@ -30,7 +30,7 @@ export function DomainTypesCard({
     domain.types != null &&
     domain.types.length !== 0 && (
       <>
-        <h2 className="font-bold text-lg mt-4 mb-2 max-w-4xl mx-auto">Types</h2>
+        <h2 className="font-bold text-lg mt-4 mb-2 max-w-5xl mx-auto">Types</h2>
         <Card>
           {domain.types.map((type, index) => (
             <div key={type.id} className="group">

--- a/app/devtools-protocol/[version]/page.tsx
+++ b/app/devtools-protocol/[version]/page.tsx
@@ -61,6 +61,12 @@ export default async function ProtocolVersionPage({
           protocolImplementationData={protocolImplementationData}
         />
         <ImplementationStats
+          implementationId="hermes-legacy"
+          implementation={implementationModelsById.get('hermes-legacy')!}
+          protocol={protocol.protocol}
+          protocolImplementationData={protocolImplementationData}
+        />
+        <ImplementationStats
           implementationId="react-native-hermes"
           implementation={implementationModelsById.get('react-native-hermes')!}
           protocol={protocol.protocol}

--- a/data/CdpComments.test.tsx
+++ b/data/CdpComments.test.tsx
@@ -56,6 +56,8 @@ const y = 20; // This is another inline @cdp symbol1 comment
 
 // @cdp symbol3's mentions can use punctuation without confusing the parser.
 // @cdp symbol3.@cdp symbol3, @cdp symbol3?
+
+/// @cdp symbol4 in a doxygen-style comment
 `,
     ],
   ] as const;

--- a/data/CdpComments.tsx
+++ b/data/CdpComments.tsx
@@ -65,7 +65,7 @@ function cleanCommentSource(comment: string) {
     .replace(/^\/\*\*?/, '')
     .replace(/\*\/$/, '')
     // Remove line comment start tokens
-    .replace(/^\s*\/\/\s*/gm, '')
+    .replace(/^\s*\/\/\/?\s*/gm, '')
     // Remove leading asterisks from each line
     .replace(/^\s*\* ?/gm, '')
     // Remove leading/trailing newlines

--- a/data/HermesImplementationModel.tsx
+++ b/data/HermesImplementationModel.tsx
@@ -281,7 +281,7 @@ export class HermesImplementationModel
           `${domain.domain}.${type.id}`,
         );
         findAndPushMatches(
-          this.#cdpAgentSourcePaths,
+          this.#cdpCodegenSourcePaths,
           references.types,
           `${domain.domain}.${type.id}`,
           [hermesTypeId],

--- a/data/__snapshots__/CdpComments.test.tsx.snap
+++ b/data/__snapshots__/CdpComments.test.tsx.snap
@@ -220,6 +220,20 @@ note that the comment is indented
         "line": 37,
       },
     ],
+    "symbol4" => [
+      {
+        "cleanedText": "symbol4 in a doxygen-style comment",
+        "column": 1,
+        "github": {
+          "commitSha": "00000000",
+          "owner": "owner",
+          "path": "main.js",
+          "repo": "repo",
+        },
+        "hasAdditionalContent": true,
+        "line": 40,
+      },
+    ],
   },
 }
 `;

--- a/data/implementations.tsx
+++ b/data/implementations.tsx
@@ -6,10 +6,12 @@
  */
 
 import { HermesImplementationModel } from './HermesImplementationModel';
+import { HermesLegacyImplementationModel } from './HermesLegacyImplementationModel';
 import { ImplementationModel, MergedImplementationModel } from './ImplementationModel';
 import { ReactNativeImplementationModel } from './ReactNativeImplementationModel';
 
 const hermesImplementationModel = new HermesImplementationModel();
+const hermesLegacyImplementationModel = new HermesLegacyImplementationModel();
 const reactNativeImplementationModel = new ReactNativeImplementationModel();
 
 export const implementationModelsById: ReadonlyMap<
@@ -17,6 +19,7 @@ export const implementationModelsById: ReadonlyMap<
   ImplementationModel
 > = new Map<string, ImplementationModel>([
   ['hermes', hermesImplementationModel],
+  ['hermes-legacy', hermesLegacyImplementationModel],
   ['react-native', reactNativeImplementationModel],
   ['react-native-hermes', new MergedImplementationModel([reactNativeImplementationModel, hermesImplementationModel])],
 ]);

--- a/ui/components/Card.tsx
+++ b/ui/components/Card.tsx
@@ -17,7 +17,7 @@ export function Card({
   topContent?: ReactNode;
 }) {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 my-4 max-w-4xl mx-auto">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 my-4 max-w-5xl mx-auto">
       {topContent}
       {title && <h3 className="font-bold text-lg mb-2">{title}</h3>}
       <div>{children}</div>


### PR DESCRIPTION
Continuation of https://github.com/facebook/react-native-cdp-status/pull/11.

* Scrape the new Hermes CDP implementation (CDPAgent)
* Continue scraping the old Hermes CDP implementation (CDPHandler) as "Hermes (Legacy)".
  * We will likely want to remove this entirely soon enough.
  * I've tweaked the styling slightly to accommodate the longer "Hermes (Legacy)" label (37972fd) - we can probably undo this later if we want.
* Enable parsing of `@cdp` comments in the Hermes CDPAgent codebase.

Screenshots:

<img width="1068" alt="image" src="https://github.com/facebook/react-native-cdp-status/assets/2246565/14e679da-1abb-4792-b57f-af8570904dfc">

<img width="1068" alt="image" src="https://github.com/facebook/react-native-cdp-status/assets/2246565/1175f0f9-fd43-4d56-9d34-449b4bd2e70e">

<img width="1044" alt="image" src="https://github.com/facebook/react-native-cdp-status/assets/2246565/c295a9cd-0f34-48be-8a52-5b636f4e2259">
