### PR TITLE
chore: remove unused package raising security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "eslint-plugin-cdp-project": "file:./eslint/rules",
     "line-column": "^1.0.2",
     "next": "13.5.4",
-    "npm-registry-fetch": "^16.1.0",
     "octokit": "^3.1.2",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
Can't see this being used anywhere + CVE-2024-28863 (via `tar` transitive dependency)